### PR TITLE
Finish dotenv configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ API_KEY=gpt-db_api_key
 
 MONGO_USER=mongodb_username
 MONGO_PASS=mongodb_password
+MONGO_HOST=mongo:27017

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # gpt-db
+Simple FastAPI app backed by MongoDB.
+
+## Configuration
+
+Environment variables are loaded from a `.env` file. Start by copying the
+example configuration and editing the values as needed:
+
+```bash
+cp .env.example .env
+```
+
+The application expects an `API_KEY` for authentication and optional MongoDB
+connection details (`MONGO_USER`, `MONGO_PASS`, `MONGO_HOST`).
 

--- a/main.py
+++ b/main.py
@@ -7,12 +7,24 @@ from bson import ObjectId
 import os
 
 from dotenv import load_dotenv
+
 load_dotenv()
+
+API_KEY = os.getenv("API_KEY")
+if not API_KEY:
+    raise RuntimeError("API_KEY environment variable not set")
+
+mongo_user = os.getenv("MONGO_USER")
+mongo_pass = os.getenv("MONGO_PASS")
+mongo_host = os.getenv("MONGO_HOST", "mongo:27017")
+if mongo_user and mongo_pass:
+    MONGO_URL = f"mongodb://{mongo_user}:{mongo_pass}@{mongo_host}"
+else:
+    MONGO_URL = os.getenv("MONGO_URL", f"mongodb://{mongo_host}")
 
 app = FastAPI(title="BananaFuel", version="1.0.0")
 
 # ---- Mongo setup ----
-MONGO_URL = os.environ.get("MONGO_URL", "mongodb://mongo:27017")
 client = AsyncIOMotorClient(MONGO_URL)
 db = client.bananafuel
 


### PR DESCRIPTION
## Summary
- Load `API_KEY` and MongoDB credentials from environment variables
- Provide example `.env` with API and Mongo configuration
- Document `.env` setup in README

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb3e8dcfc08325a7732597d08327d9