### PR TITLE
Allow configurable server port via environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 API_KEY=gpt-db_api_key
+# Optional port for local development
+PORT=8000
 
 MONGO_USER=mongodb_username
 MONGO_PASS=mongodb_password

--- a/README.md
+++ b/README.md
@@ -4,8 +4,17 @@ Minimal FastAPI app exposing a single `/health` endpoint.
 
 ## Usage
 
+Set `PORT` to change the listening port (defaults to `8000`), then launch the server:
+
 ```bash
-uvicorn main:app
+# optional: export PORT=9000
+uvicorn main:app --port "${PORT:-8000}"
+```
+
+Check the health endpoint:
+
+```bash
+curl http://localhost:${PORT:-8000}/health
 ```
 
 The endpoint responds with:

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import FastAPI
 
 app = FastAPI()
@@ -8,4 +10,9 @@ async def health():
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run("main:app", host="0.0.0.0", port=8000)
+
+    uvicorn.run(
+        "main:app",
+        host="0.0.0.0",
+        port=int(os.environ.get("PORT", 8000)),
+    )


### PR DESCRIPTION
## Summary
- read the server port from the `PORT` environment variable with a default of 8000
- document optional `PORT` setting in `.env.example` and README
- add curl example for `/health` endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb4576150083259156238c7c2c1b47