### PR TITLE
Add Vercel configuration for FastAPI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ The endpoint responds with:
 ```json
 {"status": "ok"}
 ```
+
+## Deployment
+
+The included `vercel.json` configures Vercel to build `main.py` with `@vercel/python` and serve the FastAPI app via the `main:app` entry point.
+
+Deploy with the [Vercel CLI](https://vercel.com/docs/cli) and then verify the health endpoint:
+
+```bash
+# after `vercel deploy`
+curl https://<your-project>.vercel.app/health
+```

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "builds": [
+    {
+      "src": "main.py",
+      "use": "@vercel/python",
+      "config": {
+        "entrypoint": "main:app"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- configure project for Vercel with `vercel.json` using `@vercel/python` and `main:app` entrypoint
- document Vercel deployment and health check usage in README

## Testing
- `python -m py_compile main.py`
- `python -m json.tool vercel.json`

------
https://chatgpt.com/codex/tasks/task_e_68bb46377c7883259eb3304b49100b2f