### PR TITLE
Fix dotenv port handling and document environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,21 @@ Minimal FastAPI app exposing a single `/health` endpoint.
 
 ## Usage
 
-Set `PORT` to change the listening port (defaults to `8000`), then launch the server:
+Install dependencies and configure the environment. Configuration is read from environment variables or an optional `.env` file. At a minimum, define an `API_KEY`:
 
 ```bash
-# optional: export PORT=9000
+pip install -r requirements.txt
+cp .env.example .env
+echo "API_KEY=your_api_key" >> .env
+# optional: echo "PORT=9000" >> .env
+```
+
+Run the server (defaults to port `8000`):
+
+```bash
 uvicorn main:app --port "${PORT:-8000}"
+# or
+python main.py
 ```
 
 Check the health endpoint:

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import os
+
 from dotenv import load_dotenv
 from fastapi import FastAPI
 
@@ -24,5 +25,5 @@ if __name__ == "__main__":
     uvicorn.run(
         "main:app",
         host="0.0.0.0",
-        port=int(os.environ.get("PORT", 8000)),
+        port=int(os.getenv("PORT", "8000"))
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+python-dotenv


### PR DESCRIPTION
## Summary
- normalize import order and read PORT via `os.getenv` in `main.py`
- document dependency installation and environment configuration in README
- add `python-dotenv` to requirements

## Testing
- `python -m py_compile main.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68bb47cd685c8325aa55eac653b03fe0