### PR TITLE
refactor: return friendly mongo auth error

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ curl -sS \
 If MongoDB is unreachable or misconfigured, `/list` responds with `503` and a JSON error:
 
 ```json
-{"detail":{"error":"Failed to connect to MongoDB","reason":"<message>"}}
+{
+  "error": true,
+  "type": "DatabaseAuthenticationError",
+  "message": "Unable to connect to MongoDB: authentication failed. Please check your username, password, or connection string.",
+  "code": 8000,
+  "service": "MongoDB Atlas"
+}
 ```
 
 ## Project Structure


### PR DESCRIPTION
## Summary
- format MongoDB errors into a consistent schema
- document new error response in README

## Testing
- `python -m py_compile app/api/routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb7c860b083259f755c7d43dde6f3