### PR TITLE
Add food stock endpoints to API

### DIFF
--- a/app/api/food.py
+++ b/app/api/food.py
@@ -1,0 +1,53 @@
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, status
+from fastapi.responses import JSONResponse
+
+from app.api.deps import require_api_key
+from app.api.utils import format_mongo_error
+from app.db.mongo import get_mongo_client
+
+router = APIRouter(prefix="/food", tags=["food"])
+
+
+def _serialize(doc: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert Mongo document to JSON-serializable dict."""
+    result = dict(doc)
+    if "_id" in result:
+        result["_id"] = str(result["_id"])
+    return result
+
+
+@router.get("/stock", dependencies=[Depends(require_api_key)])
+async def get_food_stock() -> JSONResponse:
+    """Return all items in `food.stock` collection."""
+    try:
+        client = get_mongo_client()
+        collection = client.get_database("food").get_collection("stock")
+        docs = await collection.find().to_list(length=None)
+        items = [_serialize(doc) for doc in docs]
+        return JSONResponse(content={"items": items})
+    except Exception as e:
+        content = format_mongo_error(e)
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, content=content
+        )
+
+
+@router.post("/stock", dependencies=[Depends(require_api_key)])
+async def add_food_stock(items: List[Dict[str, Any]]) -> JSONResponse:
+    """Insert one or more items into `food.stock` collection."""
+    try:
+        client = get_mongo_client()
+        collection = client.get_database("food").get_collection("stock")
+        result = await collection.insert_many(items)
+        ids = [str(_id) for _id in result.inserted_ids]
+        return JSONResponse(
+            status_code=status.HTTP_201_CREATED,
+            content={"inserted_ids": ids},
+        )
+    except Exception as e:
+        content = format_mongo_error(e)
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, content=content
+        )

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -4,30 +4,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
 
 from app.api.deps import require_api_key
+from app.api.food import router as food_router
+from app.api.utils import format_mongo_error
 from app.db.mongo import get_mongo_client
 
 router = APIRouter()
-
-
-def format_mongo_error(exc: Exception) -> Dict[str, Any]:
-    """Produce a user-friendly MongoDB error response."""
-    message = str(exc)
-    if "Authentication failed" in message:
-        return {
-            "error": True,
-            "type": "DatabaseAuthenticationError",
-            "message": (
-                "Unable to connect to MongoDB: authentication failed. "
-                "Please check your username, password, or connection string."
-            ),
-            "code": 8000,
-            "service": "MongoDB Atlas",
-        }
-    return {
-        "error": True,
-        "type": "DatabaseConnectionError",
-        "message": "Failed to connect to MongoDB.",
-    }
+router.include_router(food_router)
 
 
 @router.get("/")

--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict
+
+
+def format_mongo_error(exc: Exception) -> Dict[str, Any]:
+    """Produce a user-friendly MongoDB error response."""
+    message = str(exc)
+    if "Authentication failed" in message:
+        return {
+            "error": True,
+            "type": "DatabaseAuthenticationError",
+            "message": (
+                "Unable to connect to MongoDB: authentication failed. "
+                "Please check your username, password, or connection string."
+            ),
+            "code": 8000,
+            "service": "MongoDB Atlas",
+        }
+    return {
+        "error": True,
+        "type": "DatabaseConnectionError",
+        "message": "Failed to connect to MongoDB.",
+    }


### PR DESCRIPTION
## Summary
- add GET and POST /food/stock endpoints backed by MongoDB
- refactor Mongo error formatting to shared utility
- document food stock API usage

## Testing
- `python tests/ping-mongo.py` (fails: MONGO_URI is not set)
- `bash tests/test-api.sh` (fails: Undefined variable: API_KEY)
- `python -m py_compile app/api/food.py app/api/utils.py app/api/routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdcda74fa88325a7cc01bcbfaca453