### PR TITLE
feat: add food catalog endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Experimental API to enhance ChatGPT's logging abilities. Built with FastAPI and 
 
 - `/`: Health check (no auth). Returns `{ "status": "ok" }` when the API is up.
 - `/list`: Lists MongoDB collections across accessible databases. Requires `x-api-key` header.
+- `/food/catalog`:
+  - `GET` – list products with optional filters (`q`, `upc`, `tag`).
+  - `POST` – create or update a product by `upc`.
+  - `GET /food/catalog/{product_id}` – retrieve a product.
+  - `DELETE /food/catalog/{product_id}` – delete a product (`force=true` to bypass reference checks).
 - `/food/stock`:
   - `GET` – returns all documents in the `food.stock` collection.
   - `POST` – inserts one or more JSON objects into `food.stock`.
@@ -101,7 +106,7 @@ python tests/ping-mongo.py
 - `app/`: Application package
   - `app/main.py`: Creates the FastAPI application and mounts routes
   - `app/api/routes.py`: Root route definitions and sub-router mounting
-  - `app/api/food/`: Module containing `/food/stock` endpoints
+  - `app/api/food/`: Module containing food catalog and stock endpoints
   - `app/api/deps.py`: Shared dependencies (e.g., API key auth)
   - `app/api/utils.py`: Helper utilities (e.g., Mongo error formatting)
   - `app/db/mongo.py`: MongoDB client and helpers

--- a/app/api/food/README.md
+++ b/app/api/food/README.md
@@ -1,5 +1,10 @@
 # Food Endpoints
 
+- `/food/catalog`:
+  - `GET` – list products with optional filters (`q`, `upc`, `tag`).
+  - `POST` – create or update a product by `upc`.
+  - `GET /food/catalog/{product_id}` – retrieve a product.
+  - `DELETE /food/catalog/{product_id}` – delete a product (`force=true` to bypass reference checks).
 - `/food/stock`:
   - `GET` – returns all documents in the `food.stock` collection.
   - `POST` – inserts one or more JSON objects into `food.stock`.

--- a/app/api/food/__init__.py
+++ b/app/api/food/__init__.py
@@ -1,3 +1,10 @@
-from .stock import router
+from fastapi import APIRouter
+
+from .stock import router as stock_router
+from .catalog import router as catalog_router
+
+router = APIRouter()
+router.include_router(stock_router)
+router.include_router(catalog_router)
 
 __all__ = ["router"]

--- a/app/api/food/catalog.py
+++ b/app/api/food/catalog.py
@@ -1,0 +1,137 @@
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, Query, status
+from fastapi.responses import JSONResponse
+from bson import ObjectId, errors as bson_errors
+
+from app.api.deps import require_api_key
+from app.api.utils import format_mongo_error
+from app.db.mongo import get_mongo_client
+
+router = APIRouter(prefix="/food", tags=["food"])
+
+
+def _serialize(doc: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert Mongo document to JSON-serializable dict."""
+    result = dict(doc)
+    if "_id" in result:
+        result["_id"] = str(result["_id"])
+    return result
+
+
+@router.get("/catalog", dependencies=[Depends(require_api_key)])
+async def list_products(
+    q: Optional[str] = Query(default=None),
+    upc: Optional[str] = Query(default=None),
+    tag: Optional[str] = Query(default=None),
+) -> JSONResponse:
+    """List products with optional filters."""
+    try:
+        client = get_mongo_client()
+        collection = client.get_database("food").get_collection("catalog")
+        filters: Dict[str, Any] = {}
+        if q:
+            filters["name"] = {"$regex": q, "$options": "i"}
+        if upc:
+            filters["upc"] = upc
+        if tag:
+            filters["tags"] = tag
+        docs = await collection.find(filters).to_list(length=None)
+        items = [_serialize(doc) for doc in docs]
+        return JSONResponse(content={"items": items})
+    except Exception as e:
+        content = format_mongo_error(e)
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, content=content
+        )
+
+
+@router.post("/catalog", dependencies=[Depends(require_api_key)])
+async def upsert_product(product: Dict[str, Any]) -> JSONResponse:
+    """Create or update a product by UPC."""
+    try:
+        client = get_mongo_client()
+        collection = client.get_database("food").get_collection("catalog")
+        if "upc" in product:
+            await collection.update_one(
+                {"upc": product["upc"]}, {"$set": product}, upsert=True
+            )
+            doc = await collection.find_one({"upc": product["upc"]})
+        else:
+            result = await collection.insert_one(product)
+            doc = await collection.find_one({"_id": result.inserted_id})
+        return JSONResponse(
+            status_code=status.HTTP_201_CREATED, content={"item": _serialize(doc)}
+        )
+    except Exception as e:
+        content = format_mongo_error(e)
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, content=content
+        )
+
+
+@router.get("/catalog/{product_id}", dependencies=[Depends(require_api_key)])
+async def get_product(product_id: str) -> JSONResponse:
+    """Retrieve a product by its ID."""
+    try:
+        client = get_mongo_client()
+        collection = client.get_database("food").get_collection("catalog")
+        doc = await collection.find_one({"_id": ObjectId(product_id)})
+        if not doc:
+            return JSONResponse(
+                status_code=status.HTTP_404_NOT_FOUND,
+                content={"error": "Product not found"},
+            )
+        return JSONResponse(content=_serialize(doc))
+    except bson_errors.InvalidId:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={"error": "Invalid product_id"},
+        )
+    except Exception as e:
+        content = format_mongo_error(e)
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, content=content
+        )
+
+
+@router.delete("/catalog/{product_id}", dependencies=[Depends(require_api_key)])
+async def delete_product(product_id: str, force: bool = False) -> JSONResponse:
+    """Delete a product if not referenced by stock or log unless forced."""
+    try:
+        client = get_mongo_client()
+        db = client.get_database("food")
+        obj_id = ObjectId(product_id)
+
+        if not force:
+            stock_count = await db.get_collection("stock").count_documents(
+                {"product_id": obj_id}
+            )
+            log_count = await db.get_collection("log").count_documents(
+                {"product_id": obj_id}
+            )
+            if stock_count > 0 or log_count > 0:
+                return JSONResponse(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    content={
+                        "error": "Product is referenced by stock or log; use force=true to delete",
+                    },
+                )
+
+        result = await db.get_collection("catalog").delete_one({"_id": obj_id})
+        if result.deleted_count == 0:
+            return JSONResponse(
+                status_code=status.HTTP_404_NOT_FOUND,
+                content={"error": "Product not found"},
+            )
+        return JSONResponse(content={"deleted": True})
+    except bson_errors.InvalidId:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={"error": "Invalid product_id"},
+        )
+    except Exception as e:
+        content = format_mongo_error(e)
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, content=content
+        )

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -9,7 +9,7 @@ from app.api.utils import format_mongo_error
 from app.db.mongo import get_mongo_client
 
 router = APIRouter()
-router.include_router(food_router)
+router.include_router(food_router)  # includes stock and catalog
 
 
 @router.get("/")


### PR DESCRIPTION
## Summary
- add catalog router for managing food products
- expose catalog endpoints for listing, CRUD operations, and guarded deletes
- document catalog API and register router in app

## Testing
- `python tests/ping-mongo.py` *(fails: MONGO_URI is not set)*
- `API_KEY=test API_URL=http://localhost:8000 bash -x tests/test-api.sh` *(fails: server unavailable)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdd4145ae483258d55c54b0b92c315