### PR TITLE
docs: expand food endpoint examples and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Experimental API to enhance ChatGPT's logging abilities. Built with FastAPI and 
   - `DELETE /food/log/{log_id}` – soft delete a log entry.
   - `POST /food/log/undo` – undo the most recent entry.
 
+Full request/response examples for `/food/catalog`, `/food/stock`, and `/food/log` are available in [app/api/food/README.md](app/api/food/README.md).
+
 ## Setup & Local Run
 
 1) Install dependencies and configure env:
@@ -62,6 +64,26 @@ curl -sS \
   -H "x-api-key: ${API_KEY}" \
   http://localhost:${PORT:-8000}/list
 # -> {"databases":[{"name":"mydb","collections":["logs","events", ...]}, ...]}
+```
+
+- List food catalog (requires API key):
+
+```bash
+curl -sS \
+  -H "x-api-key: ${API_KEY}" \
+  http://localhost:${PORT:-8000}/food/catalog
+# -> {"items": [...]}  # product list
+```
+
+- Upsert a product:
+
+```bash
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: ${API_KEY}" \
+  -d '{"upc": "0001", "name": "Apple"}' \
+  http://localhost:${PORT:-8000}/food/catalog
+# -> {"item": {"_id": "...", "upc": "0001", "name": "Apple"}}
 ```
 
 - Read food stock (requires API key):

--- a/app/api/food/README.md
+++ b/app/api/food/README.md
@@ -1,18 +1,195 @@
 # Food Endpoints
 
-- `/food/catalog`:
-  - `GET` – list products with optional filters (`q`, `upc`, `tag`).
-  - `POST` – create or update a product by `upc`.
-  - `GET /food/catalog/{product_id}` – retrieve a product.
-  - `DELETE /food/catalog/{product_id}` – delete a product (`force=true` to bypass reference checks).
-- `/food/stock`:
-  - `GET` – list stock with `view=aggregate|items`.
-  - `POST` – add units via `{ upc|product_id, quantity }`.
-  - `POST /food/stock/consume` – atomic decrement and log.
-  - `POST /food/stock/remove` – decrement with a `reason` (no nutrition log).
-  - `DELETE /food/stock/{stock_id}` – delete a specific stock document.
-- `/food/log`:
-  - `GET` – list log entries for a day (`date=YYYY-MM-DD`) with totals and remaining targets.
-  - `POST` – append a log entry manually.
-  - `DELETE /food/log/{log_id}` – soft delete a log entry.
-  - `POST /food/log/undo` – delete the most recent entry.
+All routes require the `x-api-key` header.
+
+## Catalog
+
+### `GET /food/catalog`
+List products with optional filters (`q`, `upc`, `tag`).
+
+```bash
+curl -sS -H "x-api-key: ${API_KEY}" \
+  "https://<host>/food/catalog?q=apple"
+```
+
+```json
+{
+  "items": [
+    { "_id": "64abc...", "name": "Apple", "upc": "0001", "tags": ["fruit"] }
+  ]
+}
+```
+
+### `POST /food/catalog`
+Create or update a product by `upc`.
+
+```bash
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: ${API_KEY}" \
+  -d '{"upc":"0001","name":"Apple","calories":95}' \
+  https://<host>/food/catalog
+```
+
+```json
+{
+  "item": { "_id": "64abc...", "upc": "0001", "name": "Apple", "calories": 95 }
+}
+```
+
+### `GET /food/catalog/{product_id}`
+Retrieve a product.
+
+```bash
+curl -sS -H "x-api-key: ${API_KEY}" \
+  https://<host>/food/catalog/64abcdeffedcba0123456789
+```
+
+```json
+{ "_id": "64abcdeffedcba0123456789", "upc": "0001", "name": "Apple" }
+```
+
+### `DELETE /food/catalog/{product_id}`
+Delete a product. Use `?force=true` to bypass reference checks.
+
+```bash
+curl -sS -X DELETE -H "x-api-key: ${API_KEY}" \
+  "https://<host>/food/catalog/64abcdeffedcba0123456789?force=true"
+```
+
+```json
+{ "deleted": true }
+```
+
+## Stock
+
+### `GET /food/stock`
+List stock items. Use `view=aggregate` (default) or `view=items` for raw rows.
+
+```bash
+curl -sS -H "x-api-key: ${API_KEY}" \
+  "https://<host>/food/stock?view=aggregate"
+```
+
+```json
+{
+  "items": [ { "product_id": "64abc...", "quantity": 5 } ]
+}
+```
+
+### `POST /food/stock`
+Add units for one or more products.
+
+```bash
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: ${API_KEY}" \
+  -d '[{"upc":"0001","quantity":3}]' \
+  https://<host>/food/stock
+```
+
+```json
+{ "upserted_ids": ["64def..."] }
+```
+
+### `POST /food/stock/consume`
+Atomically decrement stock and log nutrition.
+
+```bash
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: ${API_KEY}" \
+  -d '{"upc":"0001","units":1}' \
+  https://<host>/food/stock/consume
+```
+
+```json
+{ "remaining": 2 }
+```
+
+### `POST /food/stock/remove`
+Decrement without logging (requires `reason`).
+
+```bash
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: ${API_KEY}" \
+  -d '{"upc":"0001","units":1,"reason":"spoilage"}' \
+  https://<host>/food/stock/remove
+```
+
+```json
+{ "remaining": 1 }
+```
+
+### `DELETE /food/stock/{stock_id}`
+Remove a specific stock document.
+
+```bash
+curl -sS -X DELETE -H "x-api-key: ${API_KEY}" \
+  https://<host>/food/stock/64abcdeffedcba0123456789
+```
+
+```json
+{ "deleted": true }
+```
+
+## Log
+
+### `GET /food/log`
+List log entries for a day (`date=YYYY-MM-DD`) with totals and remaining targets.
+
+```bash
+curl -sS -H "x-api-key: ${API_KEY}" \
+  "https://<host>/food/log?date=2024-01-01"
+```
+
+```json
+{
+  "entries": [
+    { "_id": "64log...", "upc": "0001", "units": 1, "timestamp": "2024-01-01T12:00:00" }
+  ],
+  "totals": { "calories": 95, "protein": 0, "fat": 0, "carbs": 25 },
+  "remaining": { "calories": 1905, "protein": 150, "fat": 70, "carbs": 225 }
+}
+```
+
+### `POST /food/log`
+Append a log entry manually.
+
+```bash
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: ${API_KEY}" \
+  -d '{"upc":"0001","units":1}' \
+  https://<host>/food/log
+```
+
+```json
+{ "log_id": "64log..." }
+```
+
+### `DELETE /food/log/{log_id}`
+Soft delete a log entry.
+
+```bash
+curl -sS -X DELETE -H "x-api-key: ${API_KEY}" \
+  https://<host>/food/log/64abcdeffedcba0123456789
+```
+
+```json
+{ "deleted": true }
+```
+
+### `POST /food/log/undo`
+Delete the most recent entry.
+
+```bash
+curl -sS -X POST -H "x-api-key: ${API_KEY}" \
+  https://<host>/food/log/undo
+```
+
+```json
+{ "deleted_id": "64abc..." }
+```
+


### PR DESCRIPTION
## Summary
- document every food catalog, stock, and log endpoint with request/response examples
- reference detailed food docs from the root README and add catalog usage examples

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bddbb0e698832592f2e065a355dafc