### PR TITLE
fix: replace deprecated root validators

### DIFF
--- a/gpt_db/api/food/log.py
+++ b/gpt_db/api/food/log.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 from bson import ObjectId, errors as bson_errors
 from fastapi import APIRouter, Depends, Query, status
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, model_validator
 
 from gpt_db.api.deps import require_api_key
 from gpt_db.api.utils import format_mongo_error
@@ -30,9 +30,9 @@ class LogEntry(BaseModel):
     units: int = 1
     timestamp: Optional[datetime] = None
 
-    @root_validator
-    def _check_identifier(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        if not values.get("product_id") and not values.get("upc"):
+    @model_validator(mode="after")
+    def _check_identifier(cls, values: "LogEntry") -> "LogEntry":
+        if not values.product_id and not values.upc:
             raise ValueError("Either product_id or upc must be provided")
         return values
 

--- a/gpt_db/api/food/stock.py
+++ b/gpt_db/api/food/stock.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 from bson import ObjectId, errors as bson_errors
 from fastapi import APIRouter, Depends, Query, status
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, model_validator
 from pymongo import ReturnDocument
 
 from gpt_db.api.deps import require_api_key
@@ -21,9 +21,9 @@ class StockItem(BaseModel):
     upc: Optional[str] = None
     quantity: int
 
-    @root_validator
-    def _check_identifier(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        if not values.get("product_id") and not values.get("upc"):
+    @model_validator(mode="after")
+    def _check_identifier(cls, values: "StockItem") -> "StockItem":
+        if not values.product_id and not values.upc:
             raise ValueError("Either product_id or upc must be provided")
         return values
 
@@ -36,9 +36,9 @@ class ConsumeItem(BaseModel):
     units: int = 1
     reason: Optional[str] = None
 
-    @root_validator
-    def _check_identifier(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        if not values.get("product_id") and not values.get("upc"):
+    @model_validator(mode="after")
+    def _check_identifier(cls, values: "ConsumeItem") -> "ConsumeItem":
+        if not values.product_id and not values.upc:
             raise ValueError("Either product_id or upc must be provided")
         return values
 


### PR DESCRIPTION
## Summary
- switch food stock validators to `model_validator`
- replace deprecated root validator in food log model

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python tests/ping-mongo.py` *(fails: MONGO_URI is not set)*
- `python tests/simulate-use.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68bde7d0099883258ad24884a29d18c0