### PR TITLE
Secure documentation and add modular health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Experimental API to enhance ChatGPT's logging abilities. Built with FastAPI and 
 
 ## Endpoints
 
-- `/`: Health check (no auth). Returns `{ "status": "ok" }` when the API is up.
+- `/`: Returns `{ "message": "🍌" }` when the API key is valid.
+- `/health`: Reports service status, including MongoDB connectivity. Requires `x-api-key` header.
 - `/list`: Lists MongoDB collections across accessible databases. Requires `x-api-key` header.
   - Unauthorized requests receive a playful randomized error message.
+- `/docs`, `/redoc`, `/openapi.json`: Interactive API docs. All require `x-api-key` header.
 - `/food/catalog`:
   - `GET` – list products with optional filters (`q`, `upc`, `tag`).
   - `POST` – create or update a product by `upc`.
@@ -49,11 +51,22 @@ uvicorn gpt_db.app:app --host 0.0.0.0 --port "${PORT:-8000}"
 
 ## Usage Examples (curl)
 
-- API health:
+- Root (requires API key):
 
 ```bash
-curl -sS http://localhost:${PORT:-8000}/
-# -> {"status":"ok"}
+curl -sS \
+  -H "x-api-key: ${API_KEY}" \
+  http://localhost:${PORT:-8000}/
+# -> {"message":"🍌"}
+```
+
+- Service health (requires API key):
+
+```bash
+curl -sS \
+  -H "x-api-key: ${API_KEY}" \
+  http://localhost:${PORT:-8000}/health
+# -> {"mongo":{"status":"ok"}}
 ```
 
 - List MongoDB collections (requires API key):
@@ -225,11 +238,15 @@ Set environment variables in Vercel Project Settings:
 After deploy, verify:
 
 ```bash
-# Health (no auth)
-curl -sS https://<project>.vercel.app/
-# -> {"status":"ok"}
+# Root
+curl -sS -H "x-api-key: ${API_KEY}" https://<project>.vercel.app/
+# -> {"message":"🍌"}
 
-# Collections (with auth)
+# Service health
+curl -sS -H "x-api-key: ${API_KEY}" https://<project>.vercel.app/health
+# -> {"mongo":{"status":"ok"}}
+
+# Collections
 curl -sS -H "x-api-key: ${API_KEY}" https://<project>.vercel.app/list
 ```
 

--- a/gpt_db/api/health.py
+++ b/gpt_db/api/health.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, Depends, status
+from fastapi.responses import JSONResponse
+
+from gpt_db.api.deps import require_api_key
+from gpt_db.health import mongo_status
+
+router = APIRouter()
+
+
+@router.get("/health", dependencies=[Depends(require_api_key)])
+async def health() -> JSONResponse:
+    """Report service health information."""
+    mongo = await mongo_status()
+    status_code = (
+        status.HTTP_200_OK if mongo.get("status") == "ok" else status.HTTP_503_SERVICE_UNAVAILABLE
+    )
+    return JSONResponse(status_code=status_code, content={"mongo": mongo})

--- a/gpt_db/api/routes.py
+++ b/gpt_db/api/routes.py
@@ -5,16 +5,18 @@ from fastapi.responses import JSONResponse
 
 from gpt_db.api.deps import require_api_key
 from gpt_db.api.food import router as food_router
+from gpt_db.api.health import router as health_router
 from gpt_db.api.utils import format_mongo_error
 from gpt_db.db.mongo import get_mongo_client
 
 router = APIRouter()
 router.include_router(food_router)  # includes stock and catalog
+router.include_router(health_router)
 
 
-@router.get("/")
+@router.get("/", dependencies=[Depends(require_api_key)])
 async def root():
-    return {"status": "ok"}
+    return {"message": "🍌"}
 
 
 @router.get("/list")

--- a/gpt_db/app.py
+++ b/gpt_db/app.py
@@ -1,11 +1,33 @@
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
+from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
+from fastapi.responses import JSONResponse
 
+from gpt_db.api.deps import require_api_key
 from gpt_db.api.routes import router
 
 
 def create_app() -> FastAPI:
-    application = FastAPI(title="gpt-db")
+    application = FastAPI(
+        title="gpt-db", docs_url=None, redoc_url=None, openapi_url=None
+    )
     application.include_router(router)
+
+    @application.get(
+        "/openapi.json",
+        dependencies=[Depends(require_api_key)],
+        include_in_schema=False,
+    )
+    async def openapi() -> JSONResponse:
+        return JSONResponse(application.openapi())
+
+    @application.get("/docs", dependencies=[Depends(require_api_key)], include_in_schema=False)
+    async def swagger_ui_html():
+        return get_swagger_ui_html(openapi_url="/openapi.json", title="docs")
+
+    @application.get("/redoc", dependencies=[Depends(require_api_key)], include_in_schema=False)
+    async def redoc_html():
+        return get_redoc_html(openapi_url="/openapi.json", title="redoc")
+
     return application
 
 

--- a/gpt_db/health/__init__.py
+++ b/gpt_db/health/__init__.py
@@ -1,0 +1,15 @@
+from gpt_db.db.mongo import get_mongo_client
+
+
+async def mongo_status() -> dict[str, str]:
+    """Check MongoDB connectivity.
+
+    Returns a dict with ``status`` set to ``"ok"`` or ``"error"``.
+    On error, a ``detail`` field describes the exception.
+    """
+    try:
+        client = get_mongo_client()
+        await client.admin.command("ping")
+        return {"status": "ok"}
+    except Exception as e:
+        return {"status": "error", "detail": str(e)}

--- a/tests/simulate-use.py
+++ b/tests/simulate-use.py
@@ -77,8 +77,15 @@ def cli(ctx: click.Context, api_url: str, api_key: Optional[str]) -> None:
 @cli.command()
 @click.pass_obj
 def root(client: APIClient) -> None:
-    """Call the unauthenticated root endpoint."""
+    """Call the root endpoint (requires API key)."""
     client.request("GET", "/")
+
+
+@cli.command()
+@click.pass_obj
+def health(client: APIClient) -> None:
+    """Check service health (requires API key)."""
+    client.request("GET", "/health")
 
 
 @cli.command("list")


### PR DESCRIPTION
## Summary
- Require API key for `/docs`, `/redoc`, and `/openapi.json`
- Add `/health` endpoint that reports MongoDB status
- Require auth on `/` and return a banana greeting
- Update CLI and README for new authenticated endpoints

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdedff40688325b4b09a53e78d7ffc