### PR TITLE
Create Mongo client per request in health check

### DIFF
--- a/gpt_db/api/health/service.py
+++ b/gpt_db/api/health/service.py
@@ -1,4 +1,7 @@
-from gpt_db.db.mongo import get_mongo_client
+from fastapi import HTTPException, status
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from gpt_db.core.env import get_mongo_uri
 
 
 async def mongo_status() -> dict[str, str]:
@@ -7,9 +10,19 @@ async def mongo_status() -> dict[str, str]:
     Returns a dict with ``status`` set to ``"ok"`` or ``"error"``.
     On error, a ``detail`` field describes the exception.
     """
+    client: AsyncIOMotorClient | None = None
     try:
-        client = get_mongo_client()
+        uri = get_mongo_uri()
+        if not uri:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Server not configured: set MONGO_URI",
+            )
+        client = AsyncIOMotorClient(uri, appname="gpt-db")
         await client.admin.command("ping")
         return {"status": "ok"}
     except Exception as e:
         return {"status": "error", "detail": str(e)}
+    finally:
+        if client is not None:
+            client.close()


### PR DESCRIPTION
## Summary
- create a fresh MongoDB client for health checks and close it after ping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf79a4ab48325aafa9c2cfab641fb