### PR TITLE
Align health endpoint response with AGENTS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Experimental API to enhance ChatGPT's logging abilities. Built with FastAPI and 
 ## Endpoints
 
 - `/`: Returns `{ "message": "🍌" }` when the API key is valid.
-- `/health`: Reports service status, including MongoDB connectivity. Requires `x-api-key` header.
+- `/health`: Reports overall service status and component checks (e.g. MongoDB). Requires `x-api-key` header.
 - `/list`: Lists MongoDB collections across accessible databases. Requires `x-api-key` header.
   - Unauthorized requests receive a playful randomized error message.
 - `/docs`, `/redoc`, `/openapi.json`: Interactive API docs. All require `x-api-key` header.
@@ -66,7 +66,7 @@ curl -sS \
 curl -sS \
   -H "x-api-key: ${API_KEY}" \
   http://localhost:${PORT:-8000}/health
-# -> {"mongo":{"status":"ok"}}
+# -> {"status": "ok", "components": {"mongo": "ok", "futureComponent": "ok"}}
 ```
 
 - List MongoDB collections (requires API key):

--- a/gpt_db/api/health/__init__.py
+++ b/gpt_db/api/health/__init__.py
@@ -11,7 +11,17 @@ router = APIRouter()
 async def health() -> JSONResponse:
     """Report service health information."""
     mongo = await mongo_status()
+    components = {
+        "mongo": "ok" if mongo.get("status") == "ok" else mongo,
+        "futureComponent": "ok",
+    }
+    overall_status = "ok" if all(value == "ok" for value in components.values()) else "error"
     status_code = (
-        status.HTTP_200_OK if mongo.get("status") == "ok" else status.HTTP_503_SERVICE_UNAVAILABLE
+        status.HTTP_200_OK
+        if overall_status == "ok"
+        else status.HTTP_503_SERVICE_UNAVAILABLE
     )
-    return JSONResponse(status_code=status_code, content={"mongo": mongo})
+    return JSONResponse(
+        status_code=status_code,
+        content={"status": overall_status, "components": components},
+    )


### PR DESCRIPTION
## Summary
- Structure `/health` responses with overall status and component details, including a placeholder `futureComponent`
- Document updated health endpoint format in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdf8a9ee7483258e1c3a2ebd4c8c60