### PR TITLE
Manage Mongo client via app lifecycle

### DIFF
--- a/gpt_db/api/health/service.py
+++ b/gpt_db/api/health/service.py
@@ -16,6 +16,3 @@ async def mongo_status() -> dict[str, str]:
         return {"status": "ok"}
     except Exception as e:
         return {"status": "error", "detail": str(e)}
-    finally:
-        if client is not None:
-            client.close()

--- a/gpt_db/app.py
+++ b/gpt_db/app.py
@@ -4,12 +4,24 @@ from fastapi.responses import JSONResponse
 
 from gpt_db.api.deps import require_api_key
 from gpt_db.api.routes import router
+from gpt_db.db.mongo import close_mongo_client, get_mongo_client
 
 
 def create_app() -> FastAPI:
     application = FastAPI(
         title="gpt-db", docs_url=None, redoc_url=None, openapi_url=None
     )
+
+    @application.on_event("startup")
+    async def startup_event() -> None:
+        """Initialize resources on startup."""
+        get_mongo_client()
+
+    @application.on_event("shutdown")
+    async def shutdown_event() -> None:
+        """Clean up resources on shutdown."""
+        close_mongo_client()
+
     application.include_router(router)
 
     @application.get(

--- a/gpt_db/db/mongo.py
+++ b/gpt_db/db/mongo.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from fastapi import HTTPException, status
 from motor.motor_asyncio import AsyncIOMotorClient
 
@@ -19,4 +17,12 @@ def get_mongo_client() -> AsyncIOMotorClient:
             )
         _mongo_client = AsyncIOMotorClient(uri, appname="gpt-db")
     return _mongo_client
+
+
+def close_mongo_client() -> None:
+    """Close and reset the cached MongoDB client."""
+    global _mongo_client
+    if _mongo_client is not None:
+        _mongo_client.close()
+        _mongo_client = None
 


### PR DESCRIPTION
## Summary
- Remove manual MongoDB client closing from health service
- Add FastAPI startup/shutdown hooks to initialize and close Mongo client
- Provide helper to close and reset cached Mongo client

## Testing
- `python -m py_compile gpt_db/api/health/service.py gpt_db/app.py gpt_db/db/mongo.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be0b3cacb88325ac09e4b470eab278