### PR TITLE
feat: allow docs without auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Experimental API to enhance ChatGPT's logging abilities. Built with FastAPI and 
 - `/health`: Reports overall service status and component checks (e.g. MongoDB). Requires `x-api-key` header.
 - `/list`: Lists MongoDB collections across accessible databases. Requires `x-api-key` header.
   - Unauthorized requests receive a playful randomized error message.
-- `/docs`, `/redoc`, `/openapi.json`: Interactive API docs. All require `x-api-key` header.
+- `/docs`, `/openapi.json`: Interactive API docs, no API key required.
+- `/redoc`: Interactive API docs. Requires `x-api-key` header.
 - `/food/catalog`:
   - `GET` – list products with optional filters (`q`, `upc`, `tag`).
   - `POST` – create or update a product by `upc`.

--- a/gpt_db/app.py
+++ b/gpt_db/app.py
@@ -24,15 +24,11 @@ def create_app() -> FastAPI:
 
     application.include_router(router)
 
-    @application.get(
-        "/openapi.json",
-        dependencies=[Depends(require_api_key)],
-        include_in_schema=False,
-    )
+    @application.get("/openapi.json", include_in_schema=False)
     async def openapi() -> JSONResponse:
         return JSONResponse(application.openapi())
 
-    @application.get("/docs", dependencies=[Depends(require_api_key)], include_in_schema=False)
+    @application.get("/docs", include_in_schema=False)
     async def swagger_ui_html():
         return get_swagger_ui_html(openapi_url="/openapi.json", title="docs")
 

--- a/tests/test_docs_access.py
+++ b/tests/test_docs_access.py
@@ -1,0 +1,15 @@
+import os
+from fastapi.testclient import TestClient
+
+from gpt_db.app import create_app
+
+
+def test_docs_and_openapi_accessible_without_auth():
+    os.environ.setdefault("API_KEY", "secret")
+    os.environ.setdefault("MONGO_URI", "mongodb://example.com")
+    app = create_app()
+    with TestClient(app) as client:
+        assert client.get("/docs").status_code == 200
+        assert client.get("/openapi.json").status_code == 200
+        assert client.get("/redoc").status_code == 401
+


### PR DESCRIPTION
## Summary
- allow `/docs` and `/openapi.json` to be accessed without an API key
- update README to reflect public docs
- add test ensuring `/docs` and `/openapi.json` are open while `/redoc` remains protected

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68be10ae40dc8325b95abf02ec423967