### PR TITLE
Downgrade OpenAPI spec to v3.0.1

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.1
 info:
   title: gpt-db API
   version: 1.0.0


### PR DESCRIPTION
## Summary
- downgrade OpenAPI spec from 3.1.0 to 3.0.1 and confirm each endpoint defines an operation ID and responses object

## Testing
- `openapi-spec-validator openapi.yaml` *(fails: command not found)*
- `ruby -ryaml -e 'YAML.load_file("openapi.yaml"); puts "YAML parsed successfully"'`
- `pytest` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68be157d4df0832580649662d48231c7