### PR TITLE
Document product schema for catalog upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A unified [OpenAPI 3.1 specification](openapi.yaml) consolidates all routes unde
 - `/redoc`: Interactive API docs. Requires `x-api-key` header.
 - `/food/catalog`:
   - `GET` – list products with optional filters (`q`, `upc`, `tag`).
-  - `POST` – create or update a product by `upc`.
+  - `POST` – create or update a product by `upc`; accepts optional `tags` array.
   - `GET /food/catalog/{product_id}` – retrieve a product.
   - `DELETE /food/catalog/{product_id}` – delete a product (`force=true` to bypass reference checks).
 - `/food/stock`:
@@ -98,9 +98,9 @@ curl -sS \
 curl -sS -X POST \
   -H "Content-Type: application/json" \
   -H "x-api-key: ${API_KEY}" \
-  -d '{"upc": "0001", "name": "Apple"}' \
+  -d '{"upc": "0001", "name": "Apple", "tags": ["fruit"]}' \
   http://localhost:${PORT:-8000}/food/catalog
-# -> {"item": {"_id": "...", "upc": "0001", "name": "Apple"}}
+# -> {"item": {"_id": "...", "upc": "0001", "name": "Apple", "tags": ["fruit"]}}
 ```
 
 - Read food stock (requires API key):

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -67,6 +67,19 @@ paths:
           application/json:
             schema:
               type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+                  description: Human-readable product name
+                upc:
+                  type: string
+                  description: Barcode used for lookups
+                tags:
+                  type: array
+                  items:
+                    type: string
+                  description: Category labels for the product
       responses:
         '201':
           description: Created


### PR DESCRIPTION
## Summary
- specify name, upc, and tags in `/food/catalog` POST schema
- document optional `tags` array in README with updated example

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68be1b27bfec8325b7e45c6229dd3a95