### PR TITLE
feat: add configurable macro targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,13 @@ A unified [OpenAPI 3.1 specification](openapi.yaml) consolidates all routes unde
   - `POST` – append a log entry manually.
   - `DELETE /food/log/{log_id}` – soft delete a log entry.
   - `POST /food/log/undo` – undo the most recent entry.
+- `/food/targets`:
+  - `GET` – current macro targets (defaults to FDA Daily Values).
+  - `PATCH` – update one or more targets.
+  - `DELETE` – reset all targets to defaults.
+  - `DELETE /food/targets/{macro}` – reset a single macro to its default.
 
-Full request/response examples for `/food/catalog`, `/food/stock`, and `/food/log` are available in [gpt_db/api/food/README.md](gpt_db/api/food/README.md).
+Full request/response examples for `/food/catalog`, `/food/stock`, `/food/log`, and `/food/targets` are available in [gpt_db/api/food/README.md](gpt_db/api/food/README.md).
 
 ## Setup & Local Run
 

--- a/gpt_db/api/food/README.md
+++ b/gpt_db/api/food/README.md
@@ -197,6 +197,51 @@ curl -sS -X POST -H "x-api-key: ${API_KEY}" \
 ```json
 { "deleted_id": "64abc..." }
 ```
+## Targets
+
+### `GET /food/targets`
+Retrieve current macro targets, falling back to standard Daily Values.
+
+```bash
+curl -sS -H "x-api-key: ${API_KEY}" \
+  https://<host>/food/targets
+```
+
+```json
+{ "targets": { "calories": 2000, "protein": 50, "fat": 78, "carbs": 275 } }
+```
+
+### `PATCH /food/targets`
+Update one or more targets.
+
+```bash
+curl -sS -X PATCH \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: ${API_KEY}" \
+  -d '{"protein":60}' \
+  https://<host>/food/targets
+```
+
+```json
+{ "targets": { "calories": 2000, "protein": 60, "fat": 78, "carbs": 275 } }
+```
+
+### `DELETE /food/targets`
+Reset all targets to defaults.
+
+```bash
+curl -sS -X DELETE -H "x-api-key: ${API_KEY}" \
+  https://<host>/food/targets
+```
+
+### `DELETE /food/targets/{macro}`
+Reset a specific macro to its default.
+
+```bash
+curl -sS -X DELETE -H "x-api-key: ${API_KEY}" \
+  https://<host>/food/targets/protein
+```
+
 Add and sync details into catalog:
 
 ```bash

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -439,6 +439,52 @@ paths:
       responses:
         '200':
           description: Log entry undone
+  /food/targets:
+    get:
+      summary: Get macro targets
+      operationId: getFoodTargets
+      tags:
+        - food
+      responses:
+        '200':
+          description: Current targets
+    patch:
+      summary: Update macro targets
+      operationId: patchFoodTargets
+      tags:
+        - food
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Targets updated
+    delete:
+      summary: Reset all macro targets
+      operationId: deleteFoodTargets
+      tags:
+        - food
+      responses:
+        '200':
+          description: Targets reset
+  /food/targets/{macro}:
+    delete:
+      summary: Reset one macro target
+      operationId: deleteFoodTargetsMacro
+      tags:
+        - food
+      parameters:
+        - in: path
+          name: macro
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Target reset
 components:
   securitySchemes:
     ApiKeyAuth:


### PR DESCRIPTION
## Summary
- allow storing and editing macro targets in MongoDB
- expose CRUD routes for daily targets
- read targets from DB when returning food logs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68be34e4d7448325886dfb5309e5c234