### PR TITLE
Define macro target schema for food target updates

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -459,6 +459,20 @@ paths:
           application/json:
             schema:
               type: object
+              properties:
+                calories:
+                  type: number
+                  description: Target calories
+                protein:
+                  type: number
+                  description: Target protein grams
+                fat:
+                  type: number
+                  description: Target fat grams
+                carbs:
+                  type: number
+                  description: Target carbohydrate grams
+              additionalProperties: false
       responses:
         '200':
           description: Targets updated


### PR DESCRIPTION
## Summary
- detail macro target properties in PATCH /food/targets request body

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'gpt_db')*

------
https://chatgpt.com/codex/tasks/task_e_68be3703106483259542b4c86183bd6b