### PR TITLE
fix: remove duplicate stock properties

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -305,22 +305,6 @@ paths:
                       nutrition:
                         type: object
                         description: Optional per-unit nutrition facts to seed/update catalog
-                      name:
-                        type: string
-                        description: Optional product name to seed/update catalog
-                      tags:
-                        type: array
-                        items:
-                          type: string
-                        description: Optional tags to seed/update catalog
-                      ingredients:
-                        type: array
-                        items:
-                          type: string
-                        description: Optional ingredients to seed/update catalog
-                      nutrition:
-                        type: object
-                        description: Optional per-unit nutrition facts to seed/update catalog
       responses:
         '201':
           description: Stock added


### PR DESCRIPTION
## Summary
- remove duplicate `name`, `tags`, `ingredients`, and `nutrition` fields from `openapi.yaml` stock item schema

## Testing
- `npx @redocly/cli lint openapi.yaml` *(fails: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'gpt_db')*
- `python importer.py` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be383cd4f88325a464c137a16f1dee