### PR TITLE
Remove duplicate key error handlers

### DIFF
--- a/gpt_db/api/catalog.py
+++ b/gpt_db/api/catalog.py
@@ -6,7 +6,6 @@ from fastapi.responses import JSONResponse
 from bson import ObjectId, errors as bson_errors
 import json
 from pydantic import BaseModel, Field, model_validator, field_validator, ValidationError
-from pymongo.errors import DuplicateKeyError
 from pydantic.config import ConfigDict
 
 from gpt_db.api.deps import require_api_key
@@ -240,12 +239,6 @@ async def list_products(
         return JSONResponse(content={"items": items})
     except HTTPException:
         raise
-    except DuplicateKeyError:
-        # Unique UPC constraint violated
-        return error_response(
-            message="Product with this UPC already exists",
-            status_code=status.HTTP_409_CONFLICT,
-        )
     except Exception as e:
         content = format_mongo_error(e)
         return JSONResponse(
@@ -422,11 +415,6 @@ async def get_product(product_id: str) -> JSONResponse:
         )
     except HTTPException:
         raise
-    except DuplicateKeyError:
-        return error_response(
-            message="Product with this UPC already exists",
-            status_code=status.HTTP_409_CONFLICT,
-        )
     except Exception as e:
         content = format_mongo_error(e)
         return JSONResponse(


### PR DESCRIPTION
## Summary
- drop `DuplicateKeyError` import and handlers from catalog list and get endpoints
- rely on generic exception handling to surface 503 errors

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6f4a6e8788325b6ccce274252bc3a