### PR TITLE
Enforce positive quantities for stock and log entries

### DIFF
--- a/gpt_db/api/log.py
+++ b/gpt_db/api/log.py
@@ -21,7 +21,7 @@ class LogEntry(BaseModel):
 
     product_id: Optional[str] = None
     upc: Optional[str] = None
-    units: int = 1
+    units: int = Field(default=1, gt=0)
     timestamp: Optional[datetime] = None
 
     @model_validator(mode="after")

--- a/gpt_db/api/stock.py
+++ b/gpt_db/api/stock.py
@@ -28,7 +28,7 @@ class StockItem(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     upc: str = Field(min_length=1)
-    quantity: int
+    quantity: int = Field(gt=0)
     # Optional enrichment fields that may also update catalog
     name: Optional[str] = None
     tags: Optional[List[str]] = Field(default=None, min_length=1)
@@ -86,7 +86,7 @@ class ConsumeItem(BaseModel):
     """Payload for consuming or removing stock (UPC-only)."""
 
     upc: str = Field(min_length=1)
-    units: int = 1
+    units: int = Field(default=1, gt=0)
     reason: Optional[str] = None
 
 


### PR DESCRIPTION
## Summary
- validate that stock quantities and consume units must be greater than zero
- require positive units for manual log entries

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6f5c02b5c832582e3e37606c7aef5