### PR TITLE
Handle missing Mongo URI in health check

### DIFF
--- a/gpt_db/api/health/service.py
+++ b/gpt_db/api/health/service.py
@@ -11,8 +11,11 @@ async def mongo_status() -> dict[str, str]:
     On error, a ``detail`` field describes the exception.
     """
     client: AsyncIOMotorClient | None = None
+    uri = get_mongo_uri()
+    if uri is None:
+        return {"status": "error", "detail": "MONGO_URI not configured"}
     try:
-        client = AsyncIOMotorClient(get_mongo_uri(), server_api=ServerApi("1"))
+        client = AsyncIOMotorClient(uri, server_api=ServerApi("1"))
         await client.admin.command("ping")
         return {"status": "ok"}
     except Exception as e:


### PR DESCRIPTION
## Summary
- Validate Mongo URI presence before client initialization in health check
- Preserve ping logic for valid URIs

## Testing
- ⚠️ `PYTHONPATH=. pytest -q` *(tests hang; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f7229dac8325958705adf4d03895