### PR TITLE
feat: auto-populate catalog items from OpenFoodFacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ A unified [OpenAPI 3.1 specification](openapi.yaml) consolidates all routes unde
     across `name`, `upc`, `tags`, and `ingredients` (case-insensitive). `upc`
     matches exactly; `tag` matches within the `tags` array case-insensitively.
   - `POST` – create or update a product by `upc`.
-    - Create: if no existing item with the provided `upc` is found, requires `name`.
+    - Create: if no existing item with the provided `upc` is found, `name` is
+      normally required. If omitted, the service attempts to resolve it (and
+      other details) from OpenFoodFacts using the `upc`.
     - Update: if an item with the provided `upc` exists, performs a partial merge:
       only the fields you include are modified; other fields remain unchanged.
       To clear a field, send it explicitly as `null`.

--- a/gpt_db/api/README.md
+++ b/gpt_db/api/README.md
@@ -25,6 +25,10 @@ curl -sS -H "x-api-key: ${API_KEY}" \
 ### `POST /catalog`
 Create or update a product by `upc`.
 
+If a payload contains only `upc`, the service tries to fill in missing details
+from OpenFoodFacts. At minimum, a product name must be found; otherwise the
+request fails with `422 Unprocessable Entity`.
+
 Provide per-unit nutrition facts in a nested `nutrition` object. Supported fields include macros (e.g., `calories`, `protein`, `fat`, `carbs`, `fiber`, `sugars`), vitamins (e.g., `vitamin_c_mg`, `vitamin_d_mcg`), and minerals (e.g., `sodium_mg`, `potassium_mg`, `calcium_mg`). Optionally include `tags: string[]` and `ingredients: string[]`. For backward compatibility, top-level macro fields may be provided and will be merged into `nutrition`.
 
 Important: UPC must be a JSON string of digits. Leading zeros are significant and must be preserved. Example: `"070662404072"` (not an unquoted number).

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -60,11 +60,13 @@ paths:
           application/json:
             schema:
               type: object
-              required: [name]
               properties:
                 name:
                   type: string
-                  description: Human-readable product name
+                  description: >-
+                    Human-readable product name. If omitted, the service will
+                    attempt to resolve it from OpenFoodFacts using the provided
+                    `upc`.
                 upc:
                   type: string
                   description: |


### PR DESCRIPTION
## Summary
- allow creating catalog items with only a UPC by fetching details from OpenFoodFacts
- document UPC-only creation and OpenFoodFacts lookup in README and OpenAPI spec
- test UPC-only catalog creation and failure when no name can be fetched

## Testing
- `PYTHONPATH=. pytest tests/test_food_catalog.py tests/test_docs_access.py tests/test_food_stock.py tests/test_openapi_targets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7042080a8832599452193f3ec789a